### PR TITLE
Add basic support for non-rk3588 devices and remove python-builtin lib in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
-subprocess
 matplotlib
-re
 psutil
 argparse
-curses
-time
-traceback

--- a/watchload.py
+++ b/watchload.py
@@ -29,17 +29,20 @@ logo = [
 def get_npu_load():
     try:
         # 执行命令获取输出字符串
-        result = subprocess.run(['sudo', 'cat', '/sys/kernel/debug/rknpu/load'], stdout=subprocess.PIPE)
-        # 如果命令执行失败，返回0
+        result = subprocess.run(['sudo', 'cat', '/sys/kernel/debug/rknpu/load'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        
         if result.returncode != 0:
-            print(f"Error reading NPU load: {result.stderr}")
+            print(f"Error reading NPU load: {result.stderr.decode()}")
             return [0, 0, 0]
 
-        output = result.stdout.strip()
+        output = result.stdout.decode().strip()
         
+        # 正则匹配 Core0、Core1、Core2 的百分比
         core_loads = re.findall(r'Core\d+: *(\d+)%', output)
         if core_loads:
             loads = list(map(int, core_loads))
+        else:
+            # 正则匹配 NPU Load 的百分比
             single_load = re.search(r'NPU load: *(\d+)%', output)
             if single_load:
                 loads = [int(single_load.group(1))]

--- a/watchload.py
+++ b/watchload.py
@@ -27,23 +27,34 @@ logo = [
 
 # 获取 NPU 负载的函数
 def get_npu_load():
-    # 执行命令获取输出字符串
-    result = subprocess.run(['sudo', 'cat', '/sys/kernel/debug/rknpu/load'], stdout=subprocess.PIPE)
-    output = result.stdout.decode('utf-8').strip()
-
-    # 使用正则表达式提取负载数据
     try:
-        # 正则匹配 Core0、Core1、Core2 的百分比
-        load_data = re.findall(r'Core\d+: *(\d+)%', output)
-        if len(load_data) == 3:
-            # 返回三个核心的负载
-            return list(map(int, load_data))
-        else:
-            print("Error: Could not parse all core loads")
-            return 0, 0, 0
+        # 执行命令获取输出字符串
+        result = subprocess.run(['sudo', 'cat', '/sys/kernel/debug/rknpu/load'], stdout=subprocess.PIPE)
+        # 如果命令执行失败，返回0
+        if result.returncode != 0:
+            print(f"Error reading NPU load: {result.stderr}")
+            return [0, 0, 0]
+
+        output = result.stdout.strip()
+        
+        core_loads = re.findall(r'Core\d+: *(\d+)%', output)
+        if core_loads:
+            loads = list(map(int, core_loads))
+            single_load = re.search(r'NPU load: *(\d+)%', output)
+            if single_load:
+                loads = [int(single_load.group(1))]
+            else:
+                print(f"Unrecognized load format: {output}")
+                return [0, 0, 0]
+        
+        while len(loads) < 3:
+            loads.append(0)
+            
+        return loads[:3]
+
     except Exception as e:
-        print("Error parsing load data:", e)
-        return 0, 0, 0
+        print(f"Error parsing load data: {e}")
+        return [0, 0, 0]
 
 # 获取 CPU 负载的函数
 def get_cpu_load():

--- a/watchload.py
+++ b/watchload.py
@@ -49,11 +49,8 @@ def get_npu_load():
             else:
                 print(f"Unrecognized load format: {output}")
                 return [0, 0, 0]
-        
-        while len(loads) < 3:
-            loads.append(0)
             
-        return loads[:3]
+        return loads
 
     except Exception as e:
         print(f"Error parsing load data: {e}")


### PR DESCRIPTION
# How has this been tested?
`python3 watchload.py -m t` on OrangePi 3B, RK3566 with terminal mode
![image](https://github.com/user-attachments/assets/b514282a-c7a4-4797-a860-2357a2663011)

Please also test this on RK3588 devices, thanks!